### PR TITLE
feat(tools): ApiPlatform content-API MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ MCP Protocol (stdio/HTTP) → Tools/Resources/Prompts → gRPC Clients → Downs
 
 | Folder | Tools | Service |
 |--------|-------|---------|
-| Products/ | search, get, list brands/catalogs/categories, create/update/delete, stats, analytics (9) | ProductCatalogService |
+| Products/ | search, list, get, similar, ask_expert, list brands/catalogs/categories, create/update/delete, stats, analytics (12) | ProductCatalogService + SearchService |
+| Glossary/ | resolve canonical term across tags/specs/categories (1) | ProductCatalogService |
 | Brands/ | manage brands (1) | ProductCatalogService |
 | Catalogs/ | manage catalogs (1) | ProductCatalogService |
 | Categories/ | manage categories (1) | ProductCatalogService |

--- a/DKH.McpGateway.Application/Tools/Glossary/GlossaryLookupTool.cs
+++ b/DKH.McpGateway.Application/Tools/Glossary/GlossaryLookupTool.cs
@@ -39,17 +39,23 @@ public static class GlossaryLookupTool
         var normalizedType = type.ToLowerInvariant();
         var includeAll = normalizedType is "all" or "";
 
-        var tags = includeAll || normalizedType == "tag"
-            ? await LookupTagsAsync(tagClient, term, lang, limit, cancellationToken)
-            : new List<GlossaryMatch>();
+        var tags = new List<GlossaryMatch>();
+        if (includeAll || normalizedType == "tag")
+        {
+            tags = await LookupTagsAsync(tagClient, term, lang, limit, cancellationToken);
+        }
 
-        var specifications = includeAll || normalizedType == "specification"
-            ? await LookupSpecificationsAsync(specClient, term, lang, limit, cancellationToken)
-            : new List<GlossaryMatch>();
+        var specifications = new List<GlossaryMatch>();
+        if (includeAll || normalizedType == "specification")
+        {
+            specifications = await LookupSpecificationsAsync(specClient, term, lang, limit, cancellationToken);
+        }
 
-        var categories = includeAll || normalizedType == "category"
-            ? await LookupCategoriesAsync(categoryClient, term, lang, catalogSeoName, limit, cancellationToken)
-            : new List<GlossaryMatch>();
+        var categories = new List<GlossaryMatch>();
+        if (includeAll || normalizedType == "category")
+        {
+            categories = await LookupCategoriesAsync(categoryClient, term, lang, catalogSeoName, limit, cancellationToken);
+        }
 
         var canonical = ResolveCanonical(term, tags, specifications, categories);
 

--- a/DKH.McpGateway.Application/Tools/Glossary/GlossaryLookupTool.cs
+++ b/DKH.McpGateway.Application/Tools/Glossary/GlossaryLookupTool.cs
@@ -1,0 +1,167 @@
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.CategoryManagement.v1;
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.SpecAttributeManagement.v1;
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.TagManagement.v1;
+
+namespace DKH.McpGateway.Application.Tools.Glossary;
+
+/// <summary>
+/// MCP tool that resolves a free-text term to a canonical catalog term.
+/// The catalog "glossary" is composed of tags, specification attributes and categories;
+/// this tool searches across them and returns the best canonical match plus all candidates.
+/// </summary>
+[McpServerToolType]
+public static class GlossaryLookupTool
+{
+    [McpServerTool(Name = "glossary_lookup"), Description(
+        "Resolve a free-text term to a canonical catalog term. Searches tags, specification attributes and " +
+        "categories and returns the best canonical match plus all candidates grouped by type. " +
+        "Use the 'type' parameter to restrict the lookup. Supports multilingual lookup (lang).")]
+    public static async Task<string> ExecuteAsync(
+        IApiKeyContext apiKeyContext,
+        TagManagementService.TagManagementServiceClient tagClient,
+        SpecAttributeManagementService.SpecAttributeManagementServiceClient specClient,
+        CategoryManagementService.CategoryManagementServiceClient categoryClient,
+        [Description("Term to resolve (e.g. 'oolong', 'caffeine')")] string term,
+        [Description("Restrict lookup: 'all', 'tag', 'specification', or 'category'")] string type = "all",
+        [Description("Language code (e.g. 'en', 'ru')")] string lang = "ru",
+        [Description("Catalog SEO name (used for category lookup)")] string catalogSeoName = "main-catalog",
+        [Description("Maximum candidates per type (max 50)")] int limit = 10,
+        CancellationToken cancellationToken = default)
+    {
+        apiKeyContext.EnsurePermission(McpPermissions.Read);
+
+        if (string.IsNullOrWhiteSpace(term))
+        {
+            return McpProtoHelper.FormatError("term is required");
+        }
+
+        limit = Math.Clamp(limit, 1, 50);
+        var normalizedType = type.ToLowerInvariant();
+        var includeAll = normalizedType is "all" or "";
+
+        var tags = includeAll || normalizedType == "tag"
+            ? await LookupTagsAsync(tagClient, term, lang, limit, cancellationToken)
+            : new List<GlossaryMatch>();
+
+        var specifications = includeAll || normalizedType == "specification"
+            ? await LookupSpecificationsAsync(specClient, term, lang, limit, cancellationToken)
+            : new List<GlossaryMatch>();
+
+        var categories = includeAll || normalizedType == "category"
+            ? await LookupCategoriesAsync(categoryClient, term, lang, catalogSeoName, limit, cancellationToken)
+            : new List<GlossaryMatch>();
+
+        var canonical = ResolveCanonical(term, tags, specifications, categories);
+
+        var result = new
+        {
+            term,
+            lang,
+            canonical = canonical is null ? null : Project(canonical),
+            matches = new
+            {
+                tags = tags.Select(Project),
+                specifications = specifications.Select(Project),
+                categories = categories.Select(Project),
+            },
+        };
+
+        return JsonSerializer.Serialize(result, McpJsonDefaults.Options);
+    }
+
+    private static object Project(GlossaryMatch match) => new
+    {
+        type = match.Type,
+        name = match.Name,
+        code = match.Code,
+    };
+
+    private static async Task<List<GlossaryMatch>> LookupTagsAsync(
+        TagManagementService.TagManagementServiceClient client,
+        string term, string lang, int limit, CancellationToken ct)
+    {
+        var response = await client.ListAsync(
+            new ListTagsRequest { Search = term, Page = 1, PageSize = limit, Language = lang },
+            cancellationToken: ct);
+
+        return response.Items.Select(item => ToMatch("tag", item)).ToList();
+    }
+
+    private static async Task<List<GlossaryMatch>> LookupSpecificationsAsync(
+        SpecAttributeManagementService.SpecAttributeManagementServiceClient client,
+        string term, string lang, int limit, CancellationToken ct)
+    {
+        var response = await client.ListAsync(
+            new ListSpecAttributesRequest { Search = term, Page = 1, PageSize = limit, Language = lang },
+            cancellationToken: ct);
+
+        return response.Items.Select(item => ToMatch("specification", item)).ToList();
+    }
+
+    private static async Task<List<GlossaryMatch>> LookupCategoriesAsync(
+        CategoryManagementService.CategoryManagementServiceClient client,
+        string term, string lang, string catalogSeoName, int limit, CancellationToken ct)
+    {
+        var response = await client.GetCategoryTreeAsync(
+            new GetCategoryTreeRequest { CatalogSeoName = catalogSeoName, LanguageCode = lang },
+            cancellationToken: ct);
+
+        var matches = new List<GlossaryMatch>();
+        foreach (var node in response.RootCategories)
+        {
+            CollectCategoryMatches(node, term, matches);
+        }
+
+        return matches.Take(limit).ToList();
+    }
+
+    private static void CollectCategoryMatches(CategoryNode node, string term, List<GlossaryMatch> matches)
+    {
+        if (node.Name.Contains(term, StringComparison.OrdinalIgnoreCase))
+        {
+            matches.Add(new GlossaryMatch("category", node.Name, node.SeoName));
+        }
+
+        foreach (var child in node.Children)
+        {
+            CollectCategoryMatches(child, term, matches);
+        }
+    }
+
+    /// <summary>
+    /// Converts a protobuf list item to a glossary match by reading its JSON projection,
+    /// which avoids a compile-time dependency on the concrete contract message shape.
+    /// </summary>
+    private static GlossaryMatch ToMatch(string type, Google.Protobuf.IMessage item)
+    {
+        var element = JsonSerializer.Deserialize<JsonElement>(McpProtoHelper.Formatter.Format(item));
+        var name = ReadString(element, "name") ?? ReadString(element, "code") ?? string.Empty;
+        var code = ReadString(element, "code") ?? ReadString(element, "seoName");
+        return new GlossaryMatch(type, name, code);
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+        => element.ValueKind == JsonValueKind.Object
+           && element.TryGetProperty(propertyName, out var value)
+           && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static GlossaryMatch? ResolveCanonical(
+        string term,
+        IReadOnlyList<GlossaryMatch> tags,
+        IReadOnlyList<GlossaryMatch> specifications,
+        IReadOnlyList<GlossaryMatch> categories)
+    {
+        var ordered = tags.Concat(specifications).Concat(categories).ToList();
+        if (ordered.Count == 0)
+        {
+            return null;
+        }
+
+        return ordered.FirstOrDefault(m => string.Equals(m.Name, term, StringComparison.OrdinalIgnoreCase))
+               ?? ordered[0];
+    }
+
+    private sealed record GlossaryMatch(string Type, string Name, string? Code);
+}

--- a/DKH.McpGateway.Application/Tools/Products/AskExpertTool.cs
+++ b/DKH.McpGateway.Application/Tools/Products/AskExpertTool.cs
@@ -1,0 +1,81 @@
+using DKH.SearchService.Contracts.Filters;
+using DKH.SearchService.Contracts.Search.Api.ProductSearch.v1;
+
+namespace DKH.McpGateway.Application.Tools.Products;
+
+/// <summary>
+/// MCP tool that produces a grounded product recommendation from the catalog dataset.
+/// It runs a semantic search over the user's stated need/preferences and returns ranked,
+/// dataset-grounded candidates together with the search criteria, so the AI client can
+/// explain the recommendation without hallucinating products.
+/// </summary>
+[McpServerToolType]
+public static class AskExpertTool
+{
+    [McpServerTool(Name = "ask_expert"), Description(
+        "Get a grounded product recommendation from the catalog dataset based on a natural-language need " +
+        "(taste, occasion, preferences, constraints). Returns ranked candidates and the applied criteria so the " +
+        "recommendation can be justified from real catalog data. Supports multilingual output (lang) and " +
+        "non-commercial mode (hides prices). This tool does not invent products — it only ranks existing ones.")]
+    public static async Task<string> ExecuteAsync(
+        IApiKeyContext apiKeyContext,
+        ProductSearchService.ProductSearchServiceClient client,
+        [Description("Natural-language description of the need or preferences (e.g. 'a light floral green tea for mornings')")] string need,
+        [Description("Catalog SEO name (e.g. 'main-catalog')")] string? catalogSeoName = null,
+        [Description("Language code (e.g. 'en', 'ru')")] string lang = "ru",
+        [Description("Filter by brand SEO names (comma-separated)")] string? brandFilter = null,
+        [Description("Maximum price constraint")] double? priceMax = null,
+        [Description("Number of candidates to recommend (max 20)")] int limit = 3,
+        [Description("Non-commercial mode: hide prices and currency")] bool nonCommercial = false,
+        CancellationToken cancellationToken = default)
+    {
+        apiKeyContext.EnsurePermission(McpPermissions.Read);
+        limit = Math.Clamp(limit, 1, 20);
+
+        var brands = brandFilter?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var filterBy = TypesenseFilterBuilder.Create()
+            .CatalogSeo(catalogSeoName)
+            .LanguageCode(lang)
+            .Brands(brands)
+            .PriceRange(null, priceMax)
+            .Build();
+
+        var request = new SearchProductsRequest
+        {
+            Query = need,
+            FilterBy = filterBy,
+            Page = 1,
+            PerPage = limit,
+            VectorQuery = $"embedding:([], k:{limit})",
+        };
+
+        var response = await client.SearchProductsAsync(request, cancellationToken: cancellationToken);
+
+        var result = new
+        {
+            need,
+            criteria = new
+            {
+                lang,
+                catalogSeoName,
+                brands = brands ?? Array.Empty<string>(),
+                priceMax = nonCommercial ? null : priceMax,
+            },
+            recommendationCount = response.Hits.Count,
+            recommendations = response.Hits.Take(limit).Select((h, index) => new
+            {
+                rank = index + 1,
+                code = h.Document.Code,
+                name = h.Document.Name,
+                seoName = string.IsNullOrEmpty(h.Document.SeoName) ? h.Document.Code : h.Document.SeoName,
+                brand = string.IsNullOrEmpty(h.Document.Brand) ? null : h.Document.Brand,
+                price = nonCommercial || h.Document.CallForPrice ? (double?)null : (double)h.Document.Price,
+                currency = nonCommercial || string.IsNullOrEmpty(h.Document.Currency) ? null : h.Document.Currency,
+                inStock = h.Document.InStock,
+            }),
+        };
+
+        return JsonSerializer.Serialize(result, McpJsonDefaults.Options);
+    }
+}

--- a/DKH.McpGateway.Application/Tools/Products/GetProductTool.cs
+++ b/DKH.McpGateway.Application/Tools/Products/GetProductTool.cs
@@ -15,6 +15,7 @@ public static class GetProductTool
         [Description("Product SEO name or slug")] string productSeoName,
         [Description("Catalog SEO name")] string catalogSeoName = "main-catalog",
         [Description("Language code")] string languageCode = "ru",
+        [Description("Non-commercial mode: hide prices and currency (content-API / catalog landing usage)")] bool nonCommercial = false,
         CancellationToken cancellationToken = default)
     {
         apiKeyContext.EnsurePermission(McpPermissions.Read);
@@ -34,8 +35,8 @@ public static class GetProductTool
             name = product.Name,
             seoName = product.SeoName,
             description = product.Description,
-            price = product.CallForPrice ? (double?)null : product.Price,
-            currency = product.CurrencyCode,
+            price = nonCommercial || product.CallForPrice ? (double?)null : product.Price,
+            currency = nonCommercial ? null : product.CurrencyCode,
             brand = product.Brand?.Name,
             manufacturer = product.Manufacturer?.Name,
             categories = product.Categories.Select(static c => new { name = c.CategoryName, seoName = c.CategorySeoName }),

--- a/DKH.McpGateway.Application/Tools/Products/ListProductsTool.cs
+++ b/DKH.McpGateway.Application/Tools/Products/ListProductsTool.cs
@@ -4,50 +4,48 @@ using DKH.SearchService.Contracts.Search.Api.ProductSearch.v1;
 namespace DKH.McpGateway.Application.Tools.Products;
 
 /// <summary>
-/// MCP tool for searching products with filters, pagination, and optional semantic search.
-/// Uses SearchService (Typesense) for hybrid keyword + vector search.
+/// MCP tool for listing catalog products with filters and pagination.
+/// Unlike <see cref="SearchProductsTool"/> this returns a deterministic, browseable
+/// catalog slice (no semantic ranking) — suited for content-API / catalog landing pages.
 /// </summary>
 [McpServerToolType]
-public static class SearchProductsTool
+public static class ListProductsTool
 {
-    [McpServerTool(Name = "search_products"), Description("Search products in the catalog with optional filters for category, brand, and price range. Supports semantic search for natural language queries.")]
+    [McpServerTool(Name = "list_products"), Description(
+        "List catalog products with optional brand and price filters and pagination. " +
+        "Deterministic catalog browsing (no semantic ranking). Use 'search_products' for natural-language search. " +
+        "Supports multilingual output (lang) and non-commercial mode (hides prices).")]
     public static async Task<string> ExecuteAsync(
         IApiKeyContext apiKeyContext,
         ProductSearchService.ProductSearchServiceClient client,
-        [Description("Search query text")] string query,
         [Description("Catalog SEO name (e.g. 'main-catalog')")] string? catalogSeoName = null,
-        [Description("Language code (e.g. 'en', 'ru')")] string? languageCode = null,
+        [Description("Language code (e.g. 'en', 'ru')")] string? lang = null,
         [Description("Filter by brand SEO names (comma-separated)")] string? brandFilter = null,
         [Description("Minimum price filter")] double? priceMin = null,
         [Description("Maximum price filter")] double? priceMax = null,
-        [Description("Enable semantic search (vector-based natural language matching)")] bool semanticSearch = false,
         [Description("Page number (1-based)")] int page = 1,
         [Description("Page size (max 100)")] int pageSize = 20,
-        [Description("Non-commercial mode: hide prices and currency (content-API / catalog landing usage)")] bool nonCommercial = false,
+        [Description("Non-commercial mode: hide prices and currency")] bool nonCommercial = false,
         CancellationToken cancellationToken = default)
     {
         apiKeyContext.EnsurePermission(McpPermissions.Read);
         pageSize = Math.Clamp(pageSize, 1, 100);
+        page = Math.Max(page, 1);
 
         var filterBy = TypesenseFilterBuilder.Create()
             .CatalogSeo(catalogSeoName)
-            .LanguageCode(languageCode)
+            .LanguageCode(lang)
             .Brands(brandFilter?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             .PriceRange(priceMin, priceMax)
             .Build();
 
         var request = new SearchProductsRequest
         {
-            Query = query,
+            Query = "*",
             FilterBy = filterBy,
             Page = page,
             PerPage = pageSize,
         };
-
-        if (semanticSearch)
-        {
-            request.VectorQuery = $"embedding:([], k:{pageSize})";
-        }
 
         var response = await client.SearchProductsAsync(request, cancellationToken: cancellationToken);
 
@@ -56,7 +54,7 @@ public static class SearchProductsTool
             totalCount = response.Found,
             page,
             pageSize,
-            searchTimeMs = response.SearchTimeMs,
+            lang,
             products = response.Hits.Select(h => new
             {
                 id = h.Document.Id,

--- a/DKH.McpGateway.Application/Tools/Products/SimilarProductsTool.cs
+++ b/DKH.McpGateway.Application/Tools/Products/SimilarProductsTool.cs
@@ -1,0 +1,93 @@
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.ProductManagement.v1;
+using DKH.SearchService.Contracts.Filters;
+using DKH.SearchService.Contracts.Search.Api.ProductSearch.v1;
+
+namespace DKH.McpGateway.Application.Tools.Products;
+
+/// <summary>
+/// MCP tool for finding products similar to a given product by sensory / descriptive closeness.
+/// Resolves the source product card, then runs a semantic (vector) search over its
+/// name and description, excluding the source product from the results.
+/// </summary>
+[McpServerToolType]
+public static class SimilarProductsTool
+{
+    [McpServerTool(Name = "similar_products"), Description(
+        "Recommend products similar to a given product by sensory / descriptive closeness. " +
+        "Provide the source product slug; returns semantically nearest products (excluding the source). " +
+        "Supports multilingual output (lang) and non-commercial mode (hides prices).")]
+    public static async Task<string> ExecuteAsync(
+        IApiKeyContext apiKeyContext,
+        ProductManagementService.ProductManagementServiceClient catalogClient,
+        ProductSearchService.ProductSearchServiceClient searchClient,
+        [Description("Source product SEO name or slug")] string productSeoName,
+        [Description("Catalog SEO name")] string catalogSeoName = "main-catalog",
+        [Description("Language code (e.g. 'en', 'ru')")] string lang = "ru",
+        [Description("Maximum number of recommendations (max 50)")] int limit = 6,
+        [Description("Non-commercial mode: hide prices and currency")] bool nonCommercial = false,
+        CancellationToken cancellationToken = default)
+    {
+        apiKeyContext.EnsurePermission(McpPermissions.Read);
+        limit = Math.Clamp(limit, 1, 50);
+
+        var source = await catalogClient.GetProductDetailAsync(
+            new GetProductDetailRequest
+            {
+                CatalogSeoName = catalogSeoName,
+                ProductSeoName = productSeoName,
+                LanguageCode = lang,
+            },
+            cancellationToken: cancellationToken);
+
+        // Build a sensory profile query from the source product's name and description.
+        var profile = $"{source.Name} {source.Description}".Trim();
+
+        var filterBy = TypesenseFilterBuilder.Create()
+            .CatalogSeo(catalogSeoName)
+            .LanguageCode(lang)
+            .Build();
+
+        var request = new SearchProductsRequest
+        {
+            Query = string.IsNullOrWhiteSpace(profile) ? source.Name : profile,
+            FilterBy = filterBy,
+            Page = 1,
+            // Fetch one extra so we can drop the source product and still return `limit` items.
+            PerPage = limit + 1,
+            VectorQuery = $"embedding:([], k:{limit + 1})",
+        };
+
+        var response = await searchClient.SearchProductsAsync(request, cancellationToken: cancellationToken);
+
+        var similar = response.Hits
+            .Where(h => !string.Equals(
+                string.IsNullOrEmpty(h.Document.SeoName) ? h.Document.Code : h.Document.SeoName,
+                productSeoName,
+                StringComparison.OrdinalIgnoreCase))
+            .Take(limit)
+            .Select(h => new
+            {
+                id = h.Document.Id,
+                code = h.Document.Code,
+                name = h.Document.Name,
+                seoName = string.IsNullOrEmpty(h.Document.SeoName) ? h.Document.Code : h.Document.SeoName,
+                price = nonCommercial || h.Document.CallForPrice ? (double?)null : (double)h.Document.Price,
+                currency = nonCommercial || string.IsNullOrEmpty(h.Document.Currency) ? null : h.Document.Currency,
+                brand = string.IsNullOrEmpty(h.Document.Brand) ? null : h.Document.Brand,
+                inStock = h.Document.InStock,
+            });
+
+        var result = new
+        {
+            source = new
+            {
+                name = source.Name,
+                seoName = string.IsNullOrEmpty(source.SeoName) ? productSeoName : source.SeoName,
+            },
+            lang,
+            similar,
+        };
+
+        return JsonSerializer.Serialize(result, McpJsonDefaults.Options);
+    }
+}

--- a/docs/en/mcp-tools.md
+++ b/docs/en/mcp-tools.md
@@ -4,12 +4,15 @@ Complete reference of all MCP capabilities exposed by DKH.McpGateway.
 
 ## Tools
 
-### Products (9 tools)
+### Products (12 tools)
 
 | Tool | File | Description |
 | ---- | ---- | ----------- |
-| `search_products` | SearchProductsTool.cs | Search products by query with pagination |
-| `get_product` | GetProductTool.cs | Get detailed product information by SEO name |
+| `search_products` | SearchProductsTool.cs | Search products by query with pagination, semantic search, multilingual (`languageCode`) and non-commercial (`nonCommercial`) modes |
+| `list_products` | ListProductsTool.cs | Deterministic filtered/paginated catalog listing (no semantic ranking); multilingual and non-commercial modes |
+| `get_product` | GetProductTool.cs | Get detailed product information by SEO name; multilingual and non-commercial modes |
+| `similar_products` | SimilarProductsTool.cs | Recommend products similar to a source product by sensory/descriptive closeness (vector search) |
+| `ask_expert` | AskExpertTool.cs | Grounded recommendation from the catalog dataset for a natural-language need (semantic search + applied criteria) |
 | `manage_product` | ManageProductTool.cs | Create, update, delete, get, or list products (action parameter) |
 | `list_brands` | ListBrandsTool.cs | List all available brands |
 | `list_categories` | ListCategoriesTool.cs | List category tree for a catalog |
@@ -41,6 +44,12 @@ Complete reference of all MCP capabilities exposed by DKH.McpGateway.
 | Tool | File | Description |
 | ---- | ---- | ----------- |
 | `manage_tags` | ManageTagsTool.cs | Create, update, or delete tags (action parameter) |
+
+### Glossary (1 tool)
+
+| Tool | File | Description |
+| ---- | ---- | ----------- |
+| `glossary_lookup` | GlossaryLookupTool.cs | Resolve a free-text term to a canonical catalog term across tags, specification attributes and categories (multilingual) |
 
 ### Manufacturers (1 tool)
 

--- a/tests/DKH.McpGateway.Tests/Tools/Glossary/GlossaryLookupToolTests.cs
+++ b/tests/DKH.McpGateway.Tests/Tools/Glossary/GlossaryLookupToolTests.cs
@@ -19,7 +19,7 @@ public class GlossaryLookupToolTests
     {
         SetupTags(new ListTagsResponse());
         SetupSpecs(new ListSpecAttributesResponse());
-        SetupCategories(new GetCategoryTreeResponse());
+        SetupCategories(new CategoryTree());
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class GlossaryLookupToolTests
     [Fact]
     public async Task GlossaryLookup_CategoryMatch_ReturnsMatchesAsync()
     {
-        var tree = new GetCategoryTreeResponse();
+        var tree = new CategoryTree();
         var root = new CategoryNode { Name = "Oolong Teas", SeoName = "oolong-teas", ProductCount = 5 };
         root.Children.Add(new CategoryNode { Name = "Dark Oolong", SeoName = "dark-oolong", ProductCount = 2 });
         tree.RootCategories.Add(root);
@@ -51,7 +51,7 @@ public class GlossaryLookupToolTests
     [Fact]
     public async Task GlossaryLookup_ExactMatch_BecomesCanonicalAsync()
     {
-        var tree = new GetCategoryTreeResponse();
+        var tree = new CategoryTree();
         tree.RootCategories.Add(new CategoryNode { Name = "Oolong Teas", SeoName = "oolong-teas" });
         SetupCategories(tree);
 
@@ -128,7 +128,7 @@ public class GlossaryLookupToolTests
                 Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
             .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(response));
 
-    private void SetupCategories(GetCategoryTreeResponse response)
+    private void SetupCategories(CategoryTree response)
         => _categories.GetCategoryTreeAsync(
                 Arg.Any<GetCategoryTreeRequest>(),
                 Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())

--- a/tests/DKH.McpGateway.Tests/Tools/Glossary/GlossaryLookupToolTests.cs
+++ b/tests/DKH.McpGateway.Tests/Tools/Glossary/GlossaryLookupToolTests.cs
@@ -1,0 +1,138 @@
+using DKH.McpGateway.Application.Tools.Glossary;
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.CategoryManagement.v1;
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.SpecAttributeManagement.v1;
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.TagManagement.v1;
+
+namespace DKH.McpGateway.Tests.Tools.Glossary;
+
+public class GlossaryLookupToolTests
+{
+    private readonly IApiKeyContext _auth = ApiKeyContextMocks.FullAccess();
+    private readonly TagManagementService.TagManagementServiceClient _tags =
+        Substitute.For<TagManagementService.TagManagementServiceClient>();
+    private readonly SpecAttributeManagementService.SpecAttributeManagementServiceClient _specs =
+        Substitute.For<SpecAttributeManagementService.SpecAttributeManagementServiceClient>();
+    private readonly CategoryManagementService.CategoryManagementServiceClient _categories =
+        Substitute.For<CategoryManagementService.CategoryManagementServiceClient>();
+
+    public GlossaryLookupToolTests()
+    {
+        SetupTags(new ListTagsResponse());
+        SetupSpecs(new ListSpecAttributesResponse());
+        SetupCategories(new GetCategoryTreeResponse());
+    }
+
+    [Fact]
+    public async Task GlossaryLookup_EmptyTerm_ReturnsErrorAsync()
+    {
+        var result = await ExecuteToolAsync(" ");
+
+        Parse(result).GetProperty("success").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GlossaryLookup_CategoryMatch_ReturnsMatchesAsync()
+    {
+        var tree = new GetCategoryTreeResponse();
+        var root = new CategoryNode { Name = "Oolong Teas", SeoName = "oolong-teas", ProductCount = 5 };
+        root.Children.Add(new CategoryNode { Name = "Dark Oolong", SeoName = "dark-oolong", ProductCount = 2 });
+        tree.RootCategories.Add(root);
+        tree.RootCategories.Add(new CategoryNode { Name = "Green Teas", SeoName = "green-teas" });
+        SetupCategories(tree);
+
+        var result = await ExecuteToolAsync("oolong", type: "category");
+
+        var categories = Parse(result).GetProperty("matches").GetProperty("categories");
+        categories.GetArrayLength().Should().Be(2);
+        categories[0].GetProperty("name").GetString().Should().Be("Oolong Teas");
+        categories[0].GetProperty("type").GetString().Should().Be("category");
+    }
+
+    [Fact]
+    public async Task GlossaryLookup_ExactMatch_BecomesCanonicalAsync()
+    {
+        var tree = new GetCategoryTreeResponse();
+        tree.RootCategories.Add(new CategoryNode { Name = "Oolong Teas", SeoName = "oolong-teas" });
+        SetupCategories(tree);
+
+        var result = await ExecuteToolAsync("Oolong Teas", type: "category");
+
+        var canonical = Parse(result).GetProperty("canonical");
+        canonical.GetProperty("name").GetString().Should().Be("Oolong Teas");
+        canonical.GetProperty("type").GetString().Should().Be("category");
+    }
+
+    [Fact]
+    public async Task GlossaryLookup_NoMatches_CanonicalIsNullAsync()
+    {
+        var result = await ExecuteToolAsync("nonexistent", type: "category");
+
+        Parse(result).GetProperty("canonical").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GlossaryLookup_TagType_QueriesTagClientAsync()
+    {
+        await ExecuteToolAsync("caffeine", type: "tag");
+
+        _ = _tags.Received(1).ListAsync(
+            Arg.Is<ListTagsRequest>(r => r.Search == "caffeine" && r.Language == "ru"),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+        _ = _categories.DidNotReceive().GetCategoryTreeAsync(
+            Arg.Any<GetCategoryTreeRequest>(),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GlossaryLookup_AllType_QueriesEverySourceAsync()
+    {
+        await ExecuteToolAsync("oolong");
+
+        _ = _tags.Received(1).ListAsync(
+            Arg.Any<ListTagsRequest>(),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+        _ = _specs.Received(1).ListAsync(
+            Arg.Any<ListSpecAttributesRequest>(),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+        _ = _categories.Received(1).GetCategoryTreeAsync(
+            Arg.Any<GetCategoryTreeRequest>(),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    private Task<string> ExecuteToolAsync(
+        string term,
+        string type = "all",
+        string lang = "ru",
+        string catalogSeoName = "main-catalog",
+        int limit = 10)
+        => GlossaryLookupTool.ExecuteAsync(
+            _auth,
+            _tags,
+            _specs,
+            _categories,
+            term: term,
+            type: type,
+            lang: lang,
+            catalogSeoName: catalogSeoName,
+            limit: limit);
+
+    private void SetupTags(ListTagsResponse response)
+        => _tags.ListAsync(
+                Arg.Any<ListTagsRequest>(),
+                Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(response));
+
+    private void SetupSpecs(ListSpecAttributesResponse response)
+        => _specs.ListAsync(
+                Arg.Any<ListSpecAttributesRequest>(),
+                Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(response));
+
+    private void SetupCategories(GetCategoryTreeResponse response)
+        => _categories.GetCategoryTreeAsync(
+                Arg.Any<GetCategoryTreeRequest>(),
+                Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(response));
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+}

--- a/tests/DKH.McpGateway.Tests/Tools/Products/AskExpertToolTests.cs
+++ b/tests/DKH.McpGateway.Tests/Tools/Products/AskExpertToolTests.cs
@@ -1,0 +1,124 @@
+using DKH.McpGateway.Application.Tools.Products;
+using DKH.SearchService.Contracts.Search.Api.ProductSearch.v1;
+using DKH.SearchService.Contracts.Search.Models.ProductSearch.v1;
+
+namespace DKH.McpGateway.Tests.Tools.Products;
+
+public class AskExpertToolTests
+{
+    private readonly IApiKeyContext _auth = ApiKeyContextMocks.FullAccess();
+    private readonly ProductSearchService.ProductSearchServiceClient _client =
+        Substitute.For<ProductSearchService.ProductSearchServiceClient>();
+
+    [Fact]
+    public async Task AskExpert_ReturnsRankedRecommendationsAsync()
+    {
+        var response = new SearchProductsResponse { Found = 2 };
+        response.Hits.Add(Hit("sencha", "Sencha"));
+        response.Hits.Add(Hit("gyokuro", "Gyokuro"));
+        SetupSearch(response);
+
+        var result = await ExecuteToolAsync("a light green tea for mornings");
+
+        var json = Parse(result);
+        json.GetProperty("need").GetString().Should().Be("a light green tea for mornings");
+        json.GetProperty("recommendationCount").GetInt32().Should().Be(2);
+        var recs = json.GetProperty("recommendations");
+        recs.GetArrayLength().Should().Be(2);
+        recs[0].GetProperty("rank").GetInt32().Should().Be(1);
+        recs[0].GetProperty("seoName").GetString().Should().Be("sencha");
+        recs[1].GetProperty("rank").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task AskExpert_UsesSemanticVectorQueryAsync()
+    {
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        await ExecuteToolAsync("something fruity", limit: 4);
+
+        _ = _client.Received(1).SearchProductsAsync(
+            Arg.Is<SearchProductsRequest>(r =>
+                r.Query == "something fruity" &&
+                r.VectorQuery.Contains("embedding:([]") &&
+                r.PerPage == 4),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AskExpert_WithPriceMax_EchoesCriteriaAsync()
+    {
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        var result = await ExecuteToolAsync("budget tea", priceMax: 25.0);
+
+        Parse(result).GetProperty("criteria").GetProperty("priceMax").GetDouble().Should().Be(25.0);
+    }
+
+    [Fact]
+    public async Task AskExpert_NonCommercial_HidesPriceAsync()
+    {
+        var response = new SearchProductsResponse { Found = 1 };
+        response.Hits.Add(Hit("sencha", "Sencha", price: 14.0f, currency: "USD"));
+        SetupSearch(response);
+
+        var result = await ExecuteToolAsync("green tea", nonCommercial: true);
+
+        var rec = Parse(result).GetProperty("recommendations")[0];
+        rec.GetProperty("price").ValueKind.Should().Be(JsonValueKind.Null);
+        rec.GetProperty("currency").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task AskExpert_LimitClamped_To20Async()
+    {
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        await ExecuteToolAsync("tea", limit: 100);
+
+        _ = _client.Received(1).SearchProductsAsync(
+            Arg.Is<SearchProductsRequest>(r => r.PerPage == 20),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    private static SearchHitModel Hit(string seoName, string name, float price = 0f, string currency = "")
+        => new()
+        {
+            Document = new ProductSearchModel
+            {
+                Id = Guid.NewGuid().ToString(),
+                Code = seoName.ToUpperInvariant(),
+                Name = name,
+                SeoName = seoName,
+                Price = price,
+                Currency = currency,
+            },
+        };
+
+    private Task<string> ExecuteToolAsync(
+        string need,
+        string? catalogSeoName = null,
+        string lang = "ru",
+        string? brandFilter = null,
+        double? priceMax = null,
+        int limit = 3,
+        bool nonCommercial = false)
+        => AskExpertTool.ExecuteAsync(
+            _auth,
+            _client,
+            need: need,
+            catalogSeoName: catalogSeoName,
+            lang: lang,
+            brandFilter: brandFilter,
+            priceMax: priceMax,
+            limit: limit,
+            nonCommercial: nonCommercial);
+
+    private void SetupSearch(SearchProductsResponse response)
+        => _client.SearchProductsAsync(
+                Arg.Any<SearchProductsRequest>(),
+                Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(response));
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+}

--- a/tests/DKH.McpGateway.Tests/Tools/Products/GetProductToolTests.cs
+++ b/tests/DKH.McpGateway.Tests/Tools/Products/GetProductToolTests.cs
@@ -234,16 +234,31 @@ public class GetProductToolTests
         Published = true,
     };
 
+    [Fact]
+    public async Task GetProduct_NonCommercial_HidesPriceAndCurrencyAsync()
+    {
+        var detail = CreateProductDetail();
+        SetupGetProductDetail(detail);
+
+        var result = await ExecuteToolAsync("test-product", nonCommercial: true);
+
+        var json = Parse(result);
+        json.GetProperty("price").ValueKind.Should().Be(JsonValueKind.Null);
+        json.GetProperty("currency").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
     private Task<string> ExecuteToolAsync(
         string productSeoName,
         string catalogSeoName = "main-catalog",
-        string languageCode = "ru")
+        string languageCode = "ru",
+        bool nonCommercial = false)
         => GetProductTool.ExecuteAsync(
             _auth,
             _client,
             productSeoName: productSeoName,
             catalogSeoName: catalogSeoName,
-            languageCode: languageCode);
+            languageCode: languageCode,
+            nonCommercial: nonCommercial);
 
     private void SetupGetProductDetail(ProductDetail response)
         => _client.GetProductDetailAsync(

--- a/tests/DKH.McpGateway.Tests/Tools/Products/ListProductsToolTests.cs
+++ b/tests/DKH.McpGateway.Tests/Tools/Products/ListProductsToolTests.cs
@@ -1,0 +1,130 @@
+using DKH.McpGateway.Application.Tools.Products;
+using DKH.SearchService.Contracts.Search.Api.ProductSearch.v1;
+using DKH.SearchService.Contracts.Search.Models.ProductSearch.v1;
+
+namespace DKH.McpGateway.Tests.Tools.Products;
+
+public class ListProductsToolTests
+{
+    private readonly IApiKeyContext _auth = ApiKeyContextMocks.FullAccess();
+    private readonly ProductSearchService.ProductSearchServiceClient _client =
+        Substitute.For<ProductSearchService.ProductSearchServiceClient>();
+
+    [Fact]
+    public async Task ListProducts_HappyPath_ReturnsProductsAsync()
+    {
+        var response = new SearchProductsResponse { Found = 1, Page = 1 };
+        response.Hits.Add(new SearchHitModel
+        {
+            Document = new ProductSearchModel
+            {
+                Id = Guid.NewGuid().ToString(),
+                Code = "PROD-001",
+                Name = "Test Product",
+                SeoName = "test-product",
+                Price = 12.5f,
+                Currency = "USD",
+                Brand = "TestBrand",
+                InStock = true,
+            },
+        });
+        SetupSearch(response);
+
+        var result = await ExecuteToolAsync();
+
+        var json = Parse(result);
+        json.GetProperty("totalCount").GetInt32().Should().Be(1);
+        json.GetProperty("products").GetArrayLength().Should().Be(1);
+        json.GetProperty("products")[0].GetProperty("seoName").GetString().Should().Be("test-product");
+    }
+
+    [Fact]
+    public async Task ListProducts_UsesMatchAllQueryAsync()
+    {
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        await ExecuteToolAsync();
+
+        _ = _client.Received(1).SearchProductsAsync(
+            Arg.Is<SearchProductsRequest>(r => r.Query == "*" && string.IsNullOrEmpty(r.VectorQuery)),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListProducts_WithBrandFilter_SetsFilterByAsync()
+    {
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        await ExecuteToolAsync(brandFilter: "brand-a,brand-b");
+
+        _ = _client.Received(1).SearchProductsAsync(
+            Arg.Is<SearchProductsRequest>(r => r.FilterBy.Contains("brand:=[`brand-a`,`brand-b`]")),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListProducts_PageSizeClamped_To100Async()
+    {
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        await ExecuteToolAsync(pageSize: 500);
+
+        _ = _client.Received(1).SearchProductsAsync(
+            Arg.Is<SearchProductsRequest>(r => r.PerPage == 100),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListProducts_NonCommercial_HidesPriceAsync()
+    {
+        var response = new SearchProductsResponse { Found = 1 };
+        response.Hits.Add(new SearchHitModel
+        {
+            Document = new ProductSearchModel
+            {
+                Id = Guid.NewGuid().ToString(),
+                Code = "PROD-001",
+                Name = "Test Product",
+                SeoName = "test-product",
+                Price = 12.5f,
+                Currency = "USD",
+            },
+        });
+        SetupSearch(response);
+
+        var result = await ExecuteToolAsync(nonCommercial: true);
+
+        var product = Parse(result).GetProperty("products")[0];
+        product.GetProperty("price").ValueKind.Should().Be(JsonValueKind.Null);
+        product.GetProperty("currency").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    private Task<string> ExecuteToolAsync(
+        string? catalogSeoName = null,
+        string? lang = null,
+        string? brandFilter = null,
+        double? priceMin = null,
+        double? priceMax = null,
+        int page = 1,
+        int pageSize = 20,
+        bool nonCommercial = false)
+        => ListProductsTool.ExecuteAsync(
+            _auth,
+            _client,
+            catalogSeoName: catalogSeoName,
+            lang: lang,
+            brandFilter: brandFilter,
+            priceMin: priceMin,
+            priceMax: priceMax,
+            page: page,
+            pageSize: pageSize,
+            nonCommercial: nonCommercial);
+
+    private void SetupSearch(SearchProductsResponse response)
+        => _client.SearchProductsAsync(
+                Arg.Any<SearchProductsRequest>(),
+                Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(response));
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+}

--- a/tests/DKH.McpGateway.Tests/Tools/Products/SearchProductsToolTests.cs
+++ b/tests/DKH.McpGateway.Tests/Tools/Products/SearchProductsToolTests.cs
@@ -177,6 +177,31 @@ public class SearchProductsToolTests
             .Where(e => e.StatusCode == StatusCode.Unavailable);
     }
 
+    [Fact]
+    public async Task SearchProducts_NonCommercial_HidesPriceAndCurrencyAsync()
+    {
+        var response = new SearchProductsResponse { Found = 1 };
+        response.Hits.Add(new SearchHitModel
+        {
+            Document = new ProductSearchModel
+            {
+                Id = Guid.NewGuid().ToString(),
+                Code = "PROD-001",
+                Name = "Test Product",
+                SeoName = "test-product",
+                Price = 29.99f,
+                Currency = "USD",
+            },
+        });
+        SetupSearch(response);
+
+        var result = await ExecuteToolAsync("test", nonCommercial: true);
+
+        var product = Parse(result).GetProperty("products")[0];
+        product.GetProperty("price").ValueKind.Should().Be(JsonValueKind.Null);
+        product.GetProperty("currency").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
     private Task<string> ExecuteToolAsync(
         string query,
         string? catalogSeoName = null,
@@ -186,7 +211,8 @@ public class SearchProductsToolTests
         double? priceMax = null,
         bool semanticSearch = false,
         int page = 1,
-        int pageSize = 20)
+        int pageSize = 20,
+        bool nonCommercial = false)
         => SearchProductsTool.ExecuteAsync(
             _auth,
             _client,
@@ -198,7 +224,8 @@ public class SearchProductsToolTests
             priceMax: priceMax,
             semanticSearch: semanticSearch,
             page: page,
-            pageSize: pageSize);
+            pageSize: pageSize,
+            nonCommercial: nonCommercial);
 
     private void SetupSearch(SearchProductsResponse response)
         => _client.SearchProductsAsync(

--- a/tests/DKH.McpGateway.Tests/Tools/Products/SimilarProductsToolTests.cs
+++ b/tests/DKH.McpGateway.Tests/Tools/Products/SimilarProductsToolTests.cs
@@ -1,0 +1,135 @@
+using DKH.McpGateway.Application.Tools.Products;
+using DKH.Platform.Grpc.Common.Types;
+using DKH.ProductCatalogService.Contracts.ProductCatalog.Api.ProductManagement.v1;
+using DKH.SearchService.Contracts.Search.Api.ProductSearch.v1;
+using DKH.SearchService.Contracts.Search.Models.ProductSearch.v1;
+
+namespace DKH.McpGateway.Tests.Tools.Products;
+
+public class SimilarProductsToolTests
+{
+    private readonly IApiKeyContext _auth = ApiKeyContextMocks.FullAccess();
+    private readonly ProductManagementService.ProductManagementServiceClient _catalog =
+        Substitute.For<ProductManagementService.ProductManagementServiceClient>();
+    private readonly ProductSearchService.ProductSearchServiceClient _search =
+        Substitute.For<ProductSearchService.ProductSearchServiceClient>();
+
+    [Fact]
+    public async Task SimilarProducts_ExcludesSourceAndReturnsSimilarAsync()
+    {
+        SetupSource(new ProductDetail
+        {
+            Id = new GuidValue(Guid.NewGuid().ToString()),
+            Code = "SRC",
+            Name = "Earl Grey",
+            SeoName = "earl-grey",
+            Description = "A bergamot black tea",
+        });
+
+        var response = new SearchProductsResponse { Found = 2 };
+        response.Hits.Add(Hit("earl-grey", "Earl Grey"));
+        response.Hits.Add(Hit("lady-grey", "Lady Grey"));
+        SetupSearch(response);
+
+        var result = await ExecuteToolAsync("earl-grey");
+
+        var similar = Parse(result).GetProperty("similar");
+        similar.GetArrayLength().Should().Be(1);
+        similar[0].GetProperty("seoName").GetString().Should().Be("lady-grey");
+    }
+
+    [Fact]
+    public async Task SimilarProducts_BuildsSensoryQueryAndVectorAsync()
+    {
+        SetupSource(new ProductDetail
+        {
+            Id = new GuidValue(Guid.NewGuid().ToString()),
+            Code = "SRC",
+            Name = "Earl Grey",
+            SeoName = "earl-grey",
+            Description = "bergamot black tea",
+        });
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        await ExecuteToolAsync("earl-grey", limit: 5);
+
+        _ = _search.Received(1).SearchProductsAsync(
+            Arg.Is<SearchProductsRequest>(r =>
+                r.Query.Contains("Earl Grey") &&
+                r.VectorQuery.Contains("embedding:([]") &&
+                r.PerPage == 6),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SimilarProducts_LimitClamped_To50Async()
+    {
+        SetupSource(new ProductDetail { Code = "SRC", Name = "Tea", SeoName = "tea" });
+        SetupSearch(new SearchProductsResponse { Found = 0 });
+
+        await ExecuteToolAsync("tea", limit: 999);
+
+        _ = _search.Received(1).SearchProductsAsync(
+            Arg.Is<SearchProductsRequest>(r => r.PerPage == 51),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SimilarProducts_NonCommercial_HidesPriceAsync()
+    {
+        SetupSource(new ProductDetail { Code = "SRC", Name = "Tea", SeoName = "tea" });
+        var response = new SearchProductsResponse { Found = 1 };
+        response.Hits.Add(Hit("other-tea", "Other Tea", price: 9.9f, currency: "USD"));
+        SetupSearch(response);
+
+        var result = await ExecuteToolAsync("tea", nonCommercial: true);
+
+        var similar = Parse(result).GetProperty("similar")[0];
+        similar.GetProperty("price").ValueKind.Should().Be(JsonValueKind.Null);
+        similar.GetProperty("currency").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    private static SearchHitModel Hit(string seoName, string name, float price = 0f, string currency = "")
+        => new()
+        {
+            Document = new ProductSearchModel
+            {
+                Id = Guid.NewGuid().ToString(),
+                Code = seoName.ToUpperInvariant(),
+                Name = name,
+                SeoName = seoName,
+                Price = price,
+                Currency = currency,
+            },
+        };
+
+    private Task<string> ExecuteToolAsync(
+        string productSeoName,
+        string catalogSeoName = "main-catalog",
+        string lang = "ru",
+        int limit = 6,
+        bool nonCommercial = false)
+        => SimilarProductsTool.ExecuteAsync(
+            _auth,
+            _catalog,
+            _search,
+            productSeoName: productSeoName,
+            catalogSeoName: catalogSeoName,
+            lang: lang,
+            limit: limit,
+            nonCommercial: nonCommercial);
+
+    private void SetupSource(ProductDetail detail)
+        => _catalog.GetProductDetailAsync(
+                Arg.Any<GetProductDetailRequest>(),
+                Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(detail));
+
+    private void SetupSearch(SearchProductsResponse response)
+        => _search.SearchProductsAsync(
+                Arg.Any<SearchProductsRequest>(),
+                Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(response));
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+}


### PR DESCRIPTION
## Что и зачем

Набор MCP-инструментов для витрины типа **ApiPlatform** (content-API лендинг по каталогу), чтобы AI-ассистенты (Claude Desktop, Cowork, GPT) работали с данными каталога через MCP. Все инструменты поддерживают **мультиязычность** (`lang`/`languageCode`) и **non-commercial режим** (`nonCommercial` — скрывает цены и валюту).

> Нейминг инструментов сделан **общим в product-домене** (по вашему уточнению «не tea — общие имена»), а не tea-специфичным. По решению из брифа существующие `search_products`/`get_product` **расширены**, а не продублированы.

## Маппинг на бэкенды

| Концепт из брифа | Реализация | Downstream |
|---|---|---|
| `search_teas` (семантический поиск) | расширен **`search_products`** (`nonCommercial`) | `SearchService.ProductSearchService` (5017, Typesense + векторы / EmbeddingWorker) |
| `get_tea` (карточка по slug) | расширен **`get_product`** (`nonCommercial`) | `ProductCatalog.ProductManagement.GetProductDetail` |
| `list_teas` (фильтр. пагинир. список) | **`list_products`** (new) | `SearchService.ProductSearchService` |
| `similar_teas` (сенсорная близость) | **`similar_products`** (new) | `ProductManagement.GetProductDetail` → `SearchService` (vector) |
| `ask_sommelier` (рекомендация из датасета) | **`ask_expert`** (new) | `SearchService.ProductSearchService` (semantic) |
| `glossary_lookup` (канонический термин) | **`glossary_lookup`** (new) | `ProductCatalog` Tags / SpecAttributes / Categories |

## Изменения

**Новые tools**
- `list_products` — детерминированный фильтрованный/пагинированный листинг каталога (без семантического ранжирования).
- `similar_products` — резолвит slug → карточку, строит сенсорный профиль (название + описание) и ищет ближайшие товары вектором, исключая исходный.
- `ask_expert` — обоснованная рекомендация: семантический поиск по запросу-потребности + эхо применённых критериев; **не выдумывает товары**, только ранжирует существующие.
- `glossary_lookup` — разрешает свободный термин в канонический по тегам / спец-атрибутам / категориям, возвращает лучший канонический матч + кандидатов по типам.

**Расширены**
- `search_products`, `get_product` — добавлен `nonCommercial` (скрытие цены/валюты).

**Регистрация gRPC** — новых эндпоинтов не требуется: все клиенты (`ProductSearchService`, `ProductManagement`, `TagManagement`, `SpecAttributeManagement`, `CategoryManagement`) уже зарегистрированы в `GrpcEndpointsRegistration`.

**Тесты** — на каждый новый инструмент + кейсы `nonCommercial` для расширенных (xUnit + NSubstitute + FluentAssertions, в стиле существующих).

**Документация** — обновлены `docs/en/mcp-tools.md` и таблица возможностей в `CLAUDE.md`.

## ⚠️ Важно для ревью

1. **Локальная сборка/тесты не выполнялись**: в окружении нет `dotnet` и доступа к приватному GitLab-фиду контрактов (`gitlab.thetea.app`). Код написан строго по проверенным паттернам и контрактам существующих инструментов; **финальная валидация — на CI**. Особое внимание при ревью: точные имена типов ответов `ListTagsResponse` / `ListSpecAttributesResponse` (предполагаю стандартный нейминг `List<Entity>Response`).
2. **Синхронизация темы `mcp-connect`** (StorefrontService PR #332): сейчас имена инструментов в теме — заглушки и tea-специфичны. Их нужно синхронизировать с реальными именами из этого PR: `search_products`, `get_product`, `list_products`, `similar_products`, `ask_expert`, `glossary_lookup`. Это **отдельный PR в StorefrontService** (вне scope данного репозитория).
3. **glossary_lookup** реализован поверх Tags/Specs/Categories (по вашему выбору), т.к. отдельного glossary-контракта в шлюзе нет. Если появится выделенный glossary-сервис — легко переключить.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2tXT4gm6b6vX86G3t1oH8)_