### PR TITLE
chore(deps): upgrade ModelContextProtocol SDK to 1.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,5 +122,5 @@ MCP Protocol (stdio/HTTP) → Tools/Resources/Prompts → gRPC Clients → Downs
 ## External Dependencies
 
 - DKH.Platform.* (Logging, Grpc.Client, Http)
-- ModelContextProtocol C# SDK (0.8.0-preview.1)
+- ModelContextProtocol C# SDK (1.4.0)
 - gRPC contracts from downstream services (via NuGet)

--- a/DKH.McpGateway.Api/Program.cs
+++ b/DKH.McpGateway.Api/Program.cs
@@ -18,7 +18,9 @@ var platform = Platform
         }
         else
         {
-            mcp.WithHttpTransport();
+            // MCP SDK 1.2+ disables the legacy SSE endpoints (/sse, /message) by default.
+            // Keep them enabled to preserve the documented SSE transport alongside Streamable HTTP.
+            mcp.WithHttpTransport(static options => options.EnableLegacySse = true);
         }
 
         builder.Services.AddApplication();

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
     <PackageVersion Include="DKH.Platform.Identity" Version="1.7.2"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="ModelContextProtocol" Version="0.8.0-preview.1"/>
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1"/>
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0"/>
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0"/>
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="DKH.ProductCatalogService.Contracts" Version="1.0.0"/>


### PR DESCRIPTION
Closes #70

## Что и зачем

Обновление MCP-шлюза: переход с превью-версии **ModelContextProtocol `0.8.0-preview.1` на стабильную `1.4.0`** (и `ModelContextProtocol.AspNetCore` аналогично). SDK достиг стабильного 1.x, и шлюз стоит перевести с preview на стабильный релиз.

## Изменения

- `Directory.Packages.props`: `ModelContextProtocol` и `ModelContextProtocol.AspNetCore` → `1.4.0`.
- `DKH.McpGateway.Api/Program.cs`: явно включён legacy SSE (`EnableLegacySse = true`) — см. ниже.
- `CLAUDE.md`: версия SDK в разделе зависимостей.

## Анализ совместимости

Проверил релиз-ноуты SDK 0.8 → 1.4. **Все API, которые использует шлюз, не менялись** в ходе стабилизации 1.x: `AddMcpServer`, `ServerInfo`/`Implementation`, `WithToolsFromAssembly`/`WithResourcesFromAssembly`/`WithPromptsFromAssembly`, `WithStdioServerTransport`/`WithHttpTransport`, `MapMcp`, атрибуты `McpServerToolType`/`McpServerTool`/`McpServerResource`/`McpServerPrompt`.

Breaking changes 0.9–1.4 (фильтры, `McpServerHandlers`, бинарные content-блоки, `RequestContext`-конструктор, `List`→`IList`) кодовую базу не затрагивают (проверено grep'ом). Код tools/resources/prompts менять не потребовалось.

## Одна поведенческая правка

С SDK **1.2+ legacy SSE (`/sse`, `/message`) выключен по умолчанию**. В доке шлюза SSE заявлен как транспорт, поэтому включён явно:

```csharp
mcp.WithHttpTransport(static options => options.EnableLegacySse = true);
```

> Если решите отказаться от устаревшего SSE в пользу только Streamable HTTP — уберите делегат.

## ⚠️ Важно для ревью

- **Локально не собиралось**: нет `dotnet`/доступа к приватному фиду. Анализ — по релиз-ноутам; финальная валидация на CI.
- Не трогал `DKH.Platform.*` (авто-бамп ботом) и контракты.

🤖 Generated with [Claude Code](https://claude.com/claude-code)