### PR TITLE
docs(planning): service onboarding roadmap (all services → MCP)

### DIFF
--- a/docs/planning/mcp-onboarding-execution-plan.md
+++ b/docs/planning/mcp-onboarding-execution-plan.md
@@ -1,0 +1,289 @@
+# MCP Gateway — Service Onboarding Execution Plan (Runbook)
+
+A self-contained runbook for implementing the per-service MCP onboarding work tracked in
+epic **#52** (issues **#53–#69**) and described in `services-onboarding-roadmap.md`.
+
+This is written so a **fresh session in a properly-provisioned environment** can execute it
+without re-deriving the codebase conventions. Follow it literally.
+
+---
+
+## 0. Required environment (must be true before starting)
+
+The web sandbox used to draft the plan lacked these; the executing context MUST have them:
+
+- **Repo scope**: read access to `GZDKH/DKH.McpGateway` **and** the target service repo
+  (e.g. `GZDKH/DKH.CartService`) so its `.Contracts/proto` files are readable.
+- **Private NuGet feed auth**: a working credential for `https://gitlab.thetea.app/...nuget`
+  (see `nuget.config` in the repo) so `DKH.*.Contracts` packages restore.
+- **.NET SDK 10** (see `global.json`: `10.0.102`, rollForward latestMajor, allowPrerelease).
+
+Verify up front:
+
+```bash
+dotnet --version              # 10.0.x
+dotnet restore                # must succeed (proves feed auth works)
+dotnet build -c Release       # current main must be green before you start
+dotnet test
+```
+
+If `dotnet restore` fails with 401, the feed credential is missing — stop and fix that first.
+
+---
+
+## 1. Repo conventions (non-negotiable — the build enforces them)
+
+`Directory.Build.props` sets `TreatWarningsAsErrors=true`, `EnableNETAnalyzers`,
+`EnforceCodeStyleInBuild`, `Nullable=enable`, `ImplicitUsings=enable`, `LangVersion=14`.
+`.editorconfig` raises `category-Style` and `category-CodeQuality` to **warning** (= error),
+and `IDE0055` (formatting) + `IDE0065` (using placement) to **error**.
+
+Practical rules that keep the build green (verified against existing code):
+
+- **Collection expressions**: use `[]` in target-typed positions (e.g. `x ?? []`), not
+  `new List<T>()`/`Array.Empty<T>()` *where a target type exists*. `var x = new List<T>()`
+  is fine (no target type). `Array.Empty<T>()` is also tolerated. Avoid object-creation in a
+  target-typed conditional branch (IDE0028). When in doubt, declare `var x = new List<T>();`
+  then `if (...) x = await ...;`.
+- `var` vs explicit type is not enforced (IDE0007 suggestion, IDE0008 none) — match local style.
+- `ToLowerInvariant()` is fine (used widely for `action` switches).
+- `.ToList()` is fine. `string.Equals(a, b, StringComparison.OrdinalIgnoreCase)` is preferred.
+- **No PII** ever (names, emails, phones, addresses, salaries, card data).
+- JSON output via `McpJsonDefaults.Options`. Proto↔JSON via `McpProtoHelper.Parser`/`Formatter`.
+- File-scoped namespaces; no file header; usings sorted; 4-space indent; final newline.
+- Global usings already include: `System.ComponentModel`, `System.Text.Json`,
+  `DKH.McpGateway.Application.Auth`, `DKH.McpGateway.Application.Tools.Common`,
+  `DKH.Platform.Grpc.Common.Types`, `ModelContextProtocol.Server`.
+
+---
+
+## 2. Per-service procedure (run this loop for each issue #53–#69)
+
+### Step 2.1 — Discover the contract (from the service repo)
+
+Read the target service's `*.Contracts/proto/**` and record:
+
+1. The **C# namespace(s)**: `option csharp_namespace = "DKH.<Svc>.Contracts.<Area>.Api.<Module>.v1";`
+2. Each **gRPC service** name → generated client is `<ServiceName>.<ServiceName>Client`.
+3. Each **rpc**: `rpc <Method>(<Request>) returns (<Response>);` — record method + message type names.
+4. For list endpoints, note the response fields if you want a typed projection (otherwise format
+   the whole response generically — see template B).
+
+Also record the **published package version** of `DKH.<Svc>.Contracts` from the feed:
+
+```bash
+curl -s -u <user>:<token> \
+  "https://gitlab.thetea.app/api/v4/groups/2/-/packages/nuget/metadata/dkh.<svc>.contracts/index.json" \
+  | jq '.items[].items[].catalogEntry.version'
+```
+
+### Step 2.2 — Wire up the dependency
+
+`Directory.Packages.props` — add under the contracts ItemGroup (use the real version):
+
+```xml
+<PackageVersion Include="DKH.CartService.Contracts" Version="X.Y.Z"/>
+```
+
+`DKH.McpGateway.Application/DKH.McpGateway.Application.csproj` — add under the contracts ItemGroup:
+
+```xml
+<PackageReference Include="DKH.CartService.Contracts"/>
+```
+
+### Step 2.3 — Register the gRPC clients
+
+`DKH.McpGateway.Application/GrpcEndpointsRegistration.cs` — add a `using` for each module
+namespace and, inside `AddMcpGatewayEndpoints`, a grouped block:
+
+```csharp
+// CartService (<port>)
+grpc.AddEndpointFromConfiguration<CartCrudService.CartCrudServiceClient>();
+grpc.AddEndpointFromConfiguration<CartManagementService.CartManagementServiceClient>();
+grpc.AddEndpointFromConfiguration<CartHoldService.CartHoldServiceClient>();
+grpc.AddEndpointFromConfiguration<CartClaimService.CartClaimServiceClient>();
+grpc.AddEndpointFromConfiguration<PromoCodeCrudService.PromoCodeCrudServiceClient>();
+```
+
+`AddEndpointFromConfiguration<TClient>()` resolves config by the client type name. Add the
+matching endpoint to `DKH.McpGateway.Api/appsettings.json` (and `appsettings.Development.json`)
+under `Platform:Grpc:Endpoints` — mirror an existing entry; confirm the service's gRPC port.
+
+### Step 2.4 — Write the tools (one tool per file, `Tools/<Domain>/`)
+
+**Template A — generic CRUD tool** (preferred; needs only method + message type names, not
+message fields). Mirrors the existing `ManageTagsTool` / `ManageSpecAttributeTool`.
+
+```csharp
+using DKH.CartService.Contracts.Cart.Api.PromoCodeCrud.v1;
+
+namespace DKH.McpGateway.Application.Tools.Cart;
+
+[McpServerToolType]
+public static class ManagePromoCodeTool
+{
+    [McpServerTool(Name = "manage_promo_code"), Description(
+        "Manage promo codes: create, update, delete, get, or list. " +
+        "For create/update/delete/get pass the matching request as JSON. " +
+        "For list pass optional filter JSON.")]
+    public static async Task<string> ExecuteAsync(
+        IApiKeyContext apiKeyContext,
+        PromoCodeCrudService.PromoCodeCrudServiceClient client,
+        [Description("Action: create, update, delete, get, or list")] string action,
+        [Description("Request payload as JSON (proto JSON for the chosen action)")] string? json = null,
+        CancellationToken cancellationToken = default)
+    {
+        switch (action.ToLowerInvariant())
+        {
+            case "create":
+                apiKeyContext.EnsurePermission(McpPermissions.Write);
+                return Format(await client.CreatePromoCodeAsync(
+                    Parse<CreatePromoCodeRequest>(json), cancellationToken: cancellationToken));
+            case "update":
+                apiKeyContext.EnsurePermission(McpPermissions.Write);
+                return Format(await client.UpdatePromoCodeAsync(
+                    Parse<UpdatePromoCodeRequest>(json), cancellationToken: cancellationToken));
+            case "delete":
+                apiKeyContext.EnsurePermission(McpPermissions.Write);
+                return Format(await client.DeletePromoCodeAsync(
+                    Parse<DeletePromoCodeRequest>(json), cancellationToken: cancellationToken));
+            case "get":
+                apiKeyContext.EnsurePermission(McpPermissions.Read);
+                return Format(await client.GetPromoCodeAsync(
+                    Parse<GetPromoCodeRequest>(json), cancellationToken: cancellationToken));
+            case "list":
+                apiKeyContext.EnsurePermission(McpPermissions.Read);
+                return Format(await client.ListPromoCodesAsync(
+                    Parse<ListPromoCodesRequest>(json ?? "{}"), cancellationToken: cancellationToken));
+            default:
+                return McpProtoHelper.FormatError(
+                    $"Unknown action '{action}'. Use: create, update, delete, get, or list");
+        }
+    }
+
+    private static T Parse<T>(string? json) where T : Google.Protobuf.IMessage<T>, new()
+        => McpProtoHelper.Parser.Parse<T>(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+
+    private static string Format(Google.Protobuf.IMessage message)
+        => McpProtoHelper.Formatter.Format(message);
+}
+```
+
+> Why generic: `McpProtoHelper.Parser`/`Formatter` handle every field automatically, so you do
+> not need the message internals — only the exact rpc method names and request/response type
+> names from the proto. This is the lowest-risk way to onboard a service quickly.
+> Keep the exact method names from the proto (e.g. `CreateAsync` vs `CreatePromoCodeAsync`).
+
+**Template B — read-only / typed projection** (for sensitive services where you must shape the
+output, e.g. Payment/Staff — drop PII fields explicitly). Mirror `GetProductTool`/`SearchProductsTool`:
+fetch, then build an anonymous object with only the allowed fields and serialize with
+`McpJsonDefaults.Options`. Add `lang`/`languageCode` and (for catalog-ish data) a `nonCommercial`
+flag where prices apply.
+
+Add `[Description("Language code (e.g. 'en', 'ru')")] string lang = "ru"` where the request
+supports localization, and pass it into the request.
+
+### Step 2.5 — Tests (one test class per tool)
+
+Mirror `tests/.../Tools/Tags`/`Products`. Use xUnit + NSubstitute + the helpers in
+`tests/.../Infrastructure` (`ApiKeyContextMocks.FullAccess()/ReadOnly()`, `GrpcTestHelpers`).
+gRPC client methods are mocked with the 4-arg overload:
+
+```csharp
+private readonly IApiKeyContext _auth = ApiKeyContextMocks.FullAccess();
+private readonly PromoCodeCrudService.PromoCodeCrudServiceClient _client =
+    Substitute.For<PromoCodeCrudService.PromoCodeCrudServiceClient>();
+
+[Fact]
+public async Task List_CallsClientAndReturnsJsonAsync()
+{
+    _client.ListPromoCodesAsync(
+            Arg.Any<ListPromoCodesRequest>(),
+            Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+        .Returns(GrpcTestHelpers.CreateAsyncUnaryCall(new ListPromoCodesResponse()));
+
+    var result = await ManagePromoCodeTool.ExecuteAsync(_auth, _client, "list");
+
+    JsonDocument.Parse(result); // valid JSON
+    _ = _client.Received(1).ListPromoCodesAsync(
+        Arg.Any<ListPromoCodesRequest>(),
+        Arg.Any<Metadata>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+}
+```
+
+Cover per tool: happy path per action, unknown-action error, read-only key denied on write
+(`ApiKeyContextMocks.ReadOnly()` throws on `EnsurePermission(Write)`), and an RpcException
+propagation (`GrpcTestHelpers.CreateFaultedAsyncUnaryCall<T>(StatusCode.Unavailable)`).
+
+### Step 2.6 — Docs
+
+Update `docs/en/mcp-tools.md` (add a section/rows for the service) and the capabilities table
+in `CLAUDE.md`. Keep counts accurate.
+
+### Step 2.7 — Verify & open PR
+
+```bash
+dotnet build -c Release          # zero warnings (they are errors)
+dotnet test
+dotnet format --verify-no-changes
+```
+
+Branch `claude/mcp-onboard-<service>` off `main`; **one draft PR per service**; link the issue
+(`Closes #53`). Do not push to `main`.
+
+---
+
+## 3. Ordering & parallelization
+
+All services touch the same shared files (`Directory.Packages.props`,
+`GrpcEndpointsRegistration.cs`, `appsettings*.json`, `docs/en/mcp-tools.md`, `CLAUDE.md`).
+Therefore:
+
+- **Do not run services fully in parallel on separate branches** — they will conflict on the
+  shared files and create merge churn.
+- Recommended: **sequential, one PR per service**, in phase order (Cart → Payment → Delivery →
+  Logistics → …). Merge or rebase between them.
+- If parallelism is required, split by *non-overlapping* work: one agent drafts the per-service
+  **tool + test files** (new files, no conflict) while a single integrator serially applies the
+  shared-file edits (package refs, registration, appsettings, docs). Keep the shared-file edits
+  on one branch to avoid conflicts.
+
+Per-service scope (full CRUD vs read-only / PII notes) is in each issue #53–#69 and the roadmap.
+
+---
+
+## 4. Per-service quick index
+
+| Issue | Service | Scope | gRPC services (confirm from proto) |
+|---|---|---|---|
+| #53 | CartService | CRUD | CartCrud, CartManagement, CartHold, CartClaim, PromoCodeCrud (skip `*Event`) |
+| #54 | PaymentService | read-only | payment query + ledger (confirm) — **no card data/PII** |
+| #55 | DeliveryService | CRUD/read | shipments, claims, settlements (confirm) |
+| #56 | LogisticsService | CRUD/read | rates, tariffs, delivery options (confirm) |
+| #57 | WarehouseService | CRUD | master data + operations (confirm) |
+| #58 | ProcurementService | CRUD | inbound supply workflow (confirm) |
+| #59 | CustomsService | CRUD | HS codes, declarations, certificates (confirm) |
+| #60 | NotificationService | read-only | delivery status/log (confirm) — **no recipient PII** |
+| #61 | BroadcastService | CRUD | broadcast schedule + stats (confirm) |
+| #62 | ProductRequestService | CRUD | product requests + stats (confirm) |
+| #63 | CounterpartyService | CRUD | counterparty registry (confirm) — **mind contact PII** |
+| #64 | SubscriptionService | CRUD | subscription state (confirm) |
+| #65 | MediaService | CRUD (metadata) | asset metadata (confirm) — **no binary streaming** |
+| #66 | StaffService | read-only | aggregate only — **strict NO PII** |
+| #67 | PrintService | CRUD | printers, queue, jobs (gRPC only; not SignalR) |
+| #68 | TelegramClientService | read-only | channels, messages (confirm) — **privacy** |
+| #69 | AssistantService | decision first | overlaps the gateway — resolve before building |
+
+Legacy to skip (confirm with team): CatalogService, CategoryService, Service.Scheduling.
+
+---
+
+## 5. Definition of done (per service)
+
+- [ ] `DKH.<Svc>.Contracts` referenced at the real published version; `dotnet restore` clean.
+- [ ] Clients registered; `appsettings` endpoint added.
+- [ ] Tools per the issue scope; CRUD via Template A, sensitive/typed via Template B; `lang`; no PII.
+- [ ] Tests per tool (happy/unknown-action/permission/RpcException).
+- [ ] `docs/en/mcp-tools.md` + `CLAUDE.md` updated.
+- [ ] `dotnet build -c Release` (no warnings), `dotnet test`, `dotnet format --verify-no-changes` all green.
+- [ ] Draft PR opened, linked to the issue.

--- a/docs/planning/mcp-onboarding-execution-plan.md
+++ b/docs/planning/mcp-onboarding-execution-plan.md
@@ -8,6 +8,39 @@ without re-deriving the codebase conventions. Follow it literally.
 
 ---
 
+## Required reading (do this first — per `AGENTS.md`)
+
+Before any work, read the shared GZDKH ruleset and the repo contributing guide:
+
+1. `AGENTS.md` (this repo) → its **Required Reading** points to the shared entrypoint
+   `agents/DKH.AgentRules/AGENTS.md` and `agents/DKH.AgentRules/rules/codex/triggers.md`
+   (lazy-loads SOLID/DDD, build gates, contracts, releases, docs rules). The drafting sandbox
+   did **not** have `agents/DKH.AgentRules` checked out — the executing context must, or clone it.
+2. `CONTRIBUTING.md` — workflow, Conventional Commits, branch naming, PR process, quality gates,
+   code style, **issue creation + labels + project board**. All steps below conform to it.
+3. `CLAUDE.md` "Tool Development Rules" and the `.editorconfig`.
+
+If the shared `agents/DKH.AgentRules` rules conflict with anything below, **the shared rules win** —
+update this runbook accordingly.
+
+---
+
+## Conventions (from `CONTRIBUTING.md` — apply to every service)
+
+- **Workflow order**: issue → branch from `main` → implement → quality gates → commit → PR → review → squash-merge.
+- **Issue title**: `<type>(<scope>): <description>` (e.g. `feat(cart): expose CartService via MCP`).
+  Apply a label: `type:feature` (or `type:chore`/`type:docs` as appropriate). Add to the
+  [GZDKH Project Board](https://github.com/orgs/GZDKH/projects/19).
+- **Branch**: `<type>/<issue-number>-<short-description>` (e.g. `feat/53-cartservice-mcp-tools`).
+- **Commits**: Conventional Commits, imperative mood, ≤72-char summary, scope = service area
+  (e.g. `feat(cart): add cart management tools`), one logical change per commit.
+- **PR**: Conventional-Commits title; description with summary + `Closes #<issue>` + testing notes;
+  quality gates green; ≥1 approval; **squash-merge** to `main`.
+- **Quality gates**: blocking — `dotnet build -c Release`, `dotnet test`; non-blocking (fix before
+  push) — `dotnet format --verify-no-changes`. Never commit if a blocking gate fails.
+
+---
+
 ## 0. Required environment (must be true before starting)
 
 The web sandbox used to draft the plan lacked these; the executing context MUST have them:
@@ -220,16 +253,21 @@ propagation (`GrpcTestHelpers.CreateFaultedAsyncUnaryCall<T>(StatusCode.Unavaila
 Update `docs/en/mcp-tools.md` (add a section/rows for the service) and the capabilities table
 in `CLAUDE.md`. Keep counts accurate.
 
-### Step 2.7 — Verify & open PR
+### Step 2.7 — Verify & open PR (per `CONTRIBUTING.md`)
+
+Quality gates (blocking build/test must pass before commit; format before push):
 
 ```bash
-dotnet build -c Release          # zero warnings (they are errors)
+dotnet build -c Release          # warnings are errors — must be zero
 dotnet test
 dotnet format --verify-no-changes
 ```
 
-Branch `claude/mcp-onboard-<service>` off `main`; **one draft PR per service**; link the issue
-(`Closes #53`). Do not push to `main`.
+- Branch off `main` named `<type>/<issue-number>-<short-description>`
+  (e.g. `feat/53-cartservice-mcp-tools`).
+- Commits in Conventional Commits (`feat(cart): ...`), one logical change each.
+- **One PR per service**, Conventional-Commits title; description = summary + `Closes #<issue>`
+  + testing notes; squash-merge after ≥1 approval. Do not push to `main`.
 
 ---
 

--- a/docs/planning/services-onboarding-roadmap.md
+++ b/docs/planning/services-onboarding-roadmap.md
@@ -113,5 +113,9 @@ All with `lang` and the `action` parameter pattern; no PII in cart responses.
 
 ## Tracking
 
-One GitHub issue per service (see issues labeled `mcp-onboarding`). The parent tracking
-issue links all of them and records phase ordering.
+One GitHub issue per service, titled per `CONTRIBUTING.md` (`<type>(<scope>): <description>`)
+and labelled `type:feature` (epic links them all and records phase ordering). Add issues to the
+[GZDKH Project Board](https://github.com/orgs/GZDKH/projects/19).
+
+Execution conventions (branch naming, commits, PR, quality gates, required reading) follow
+`CONTRIBUTING.md` and `AGENTS.md` — see `mcp-onboarding-execution-plan.md`.

--- a/docs/planning/services-onboarding-roadmap.md
+++ b/docs/planning/services-onboarding-roadmap.md
@@ -1,0 +1,117 @@
+# MCP Gateway — Service Onboarding Roadmap
+
+Goal: expose **every** DKH ecosystem service through the MCP gateway so AI clients
+(Claude Desktop, Cowork, GPT, Cursor) can work with the whole platform.
+
+This document is the execution plan. It is intentionally code-free: the actual tools
+must be generated against each service's real gRPC contracts and verified by CI
+(see "Execution constraints").
+
+## Current coverage (10 services)
+
+Already integrated (contracts referenced in `Directory.Packages.props`, clients in
+`GrpcEndpointsRegistration.cs`):
+
+ProductCatalogService, SearchService, ReferenceService, OrderService, ReviewService,
+StorefrontService, InventoryService, TelegramBotService, CustomerService (import/export only),
+ApiManagementService (internal auth only).
+
+## Execution constraints (read first)
+
+Each new service requires both of the following, neither of which is available in the
+remote web sandbox used to draft this plan:
+
+1. **Real gRPC contracts** — the full `.proto` request/response messages from each
+   `DKH.<Service>.Contracts` package. Reverse-engineering from snippets is not reliable.
+2. **Build + test verification** — `dotnet` plus access to the private NuGet feed
+   (`gitlab.thetea.app`) so the `DKH.<Service>.Contracts` packages restore and the
+   solution compiles. The repo enforces `TreatWarningsAsErrors` + analyzers, so code
+   must be CI-green, not merely "looks right".
+
+Therefore execution should run in an environment that has the private feed + `dotnet`,
+with read access to the service repos (to read their contracts). Work proceeds
+**one PR per service** (or small batch), each independently CI-verified.
+
+## Onboarding checklist (per service)
+
+1. Add `DKH.<Service>.Contracts` to `Directory.Packages.props` (`PackageVersion`) and to
+   `DKH.McpGateway.Application/DKH.McpGateway.Application.csproj` (`PackageReference`).
+2. Register the gRPC clients in `GrpcEndpointsRegistration.cs`
+   (`grpc.AddEndpointFromConfiguration<TClient>()`), grouped with a `// <Service> (port)` comment.
+3. Add the endpoint(s) to `appsettings*.json` under `Platform:Grpc:Endpoints`.
+4. Create tools under `Tools/<Domain>/` — one tool per file, `static class` with
+   `[McpServerToolType]`, `[McpServerTool(Name = "...")]`, typed `[Description]` params,
+   `IApiKeyContext` permission checks (`Read`/`Write`), `McpJsonDefaults.Options` for JSON.
+5. Apply the platform rules: multilingual (`lang`), **no PII**, code-based identification,
+   `action` parameter for CRUD (`create/update/delete/get/list`).
+6. Tests for every tool (xUnit + NSubstitute + FluentAssertions), mirroring existing tests.
+7. Update `docs/en/mcp-tools.md` and the capabilities table in `CLAUDE.md`.
+
+Scope decision: **full CRUD** where the service exposes management APIs; read-only where
+the data is sensitive (Payment, Staff) or inherently query-only.
+
+## Phased plan
+
+### Phase 1 — Complete the commerce transaction loop (highest value)
+
+| Service | Proposed MCP tools | Scope | Notes |
+|---|---|---|---|
+| **CartService** | `manage_cart` (CRUD/items), `manage_promo_code` (CRUD), `manage_cart_hold` (POS hold/resume), `manage_cart_claim` (claim codes) | CRUD | gRPC: CartCrud, CartManagement, CartHold, CartClaim, PromoCodeCrud (+event services are inbound-only — skip) |
+| **PaymentService** | `get_payment`, `list_payments`, `get_payment_ledger` | **Read-only** | No card data / PII; statuses + ledger only |
+| **DeliveryService** | `manage_shipment`, `get_delivery_status`, `list_claims`, `get_settlement` | CRUD (status), read for settlements | |
+| **LogisticsService** | `calculate_rate`, `list_delivery_options`, `manage_tariff` | CRUD for tariffs, read for rates | Public-facing rate engine |
+
+### Phase 2 — Supply & fulfillment operations
+
+| Service | Proposed MCP tools | Scope | Notes |
+|---|---|---|---|
+| **WarehouseService** | `manage_warehouse`, `list_warehouses`, warehouse operations | CRUD | master data + operations workflows |
+| **ProcurementService** | `manage_procurement_request`, `list_procurement`, inbound supply workflow | CRUD | |
+| **CustomsService** | `lookup_hs_code`, `manage_declaration`, `list_certificates` | CRUD | HS codes, declarations, certificates |
+
+### Phase 3 — Engagement, demand & partners
+
+| Service | Proposed MCP tools | Scope | Notes |
+|---|---|---|---|
+| **NotificationService** | `get_notification_status`, `list_notifications` | **Read-only** | delivery logs; sending stays server-driven |
+| **BroadcastService** | `manage_broadcast`, `list_broadcasts`, `get_broadcast_stats` | CRUD (schedule) | Telegram/WhatsApp/WeChat scheduled broadcasts |
+| **ProductRequestService** | `manage_product_request`, `list_product_requests`, `get_request_stats` | CRUD | customer requests for missing products |
+| **CounterpartyService** | `manage_counterparty`, `list_counterparties`, `get_counterparty` | CRUD | partner/counterparty registry; mind PII on contacts |
+
+### Phase 4 — Platform & administration
+
+| Service | Proposed MCP tools | Scope | Notes |
+|---|---|---|---|
+| **SubscriptionService** | `get_subscription`, `list_subscriptions`, `manage_subscription` | CRUD (state) | paid-product subscription state |
+| **MediaService** | `list_media`, `get_media`, `manage_media` (metadata) | CRUD (metadata) | assets; do not stream binaries through MCP |
+| **StaffService** | `get_staff_summary`, `list_roles` | **Read-only, no PII** | HR records — strict PII exclusion |
+| **PrintService** | `list_printers`, `get_print_queue`, `manage_print_job` | CRUD | printer registry, queue, routing |
+| **TelegramClientService** | `list_monitored_channels`, `get_channel_messages` | Read-only | MTProto channel monitoring |
+| **AssistantService** | TBD — overlaps with the gateway itself | Discuss | AI assistant w/ Schema Discovery + RAG; decide relationship before integrating |
+
+### Excluded — legacy / superseded
+
+`DKH.CatalogService`, `DKH.CategoryService`, `DKH.Service.Scheduling` — appear superseded by
+ProductCatalogService / ReferenceService. Confirm before discarding.
+
+## Worked example — CartService (Phase 1, ready to execute)
+
+From the contracts repo `DKH.CartService.Contracts` the gRPC services are:
+`CartCrudService`, `CartManagementService`, `CartHoldService`, `CartClaimService`,
+`PromoCodeCrudService` (plus inbound `*EventService` definitions consumed by workers —
+not exposed via MCP). C# namespaces follow `DKH.CartService.Contracts.Cart.Api.<Module>.v1`.
+
+Proposed tools:
+
+- `manage_cart` — list/get carts (admin, optional storefront filter), via `CartCrudService`.
+- `manage_cart_items` — add/update/remove items, via `CartManagementService`.
+- `manage_cart_hold` — hold/resume carts for POS, via `CartHoldService`.
+- `manage_cart_claim` — issue/redeem claim codes (QR + human-typeable), via `CartClaimService`.
+- `manage_promo_code` — CRUD promo codes, via `PromoCodeCrudService`.
+
+All with `lang` and the `action` parameter pattern; no PII in cart responses.
+
+## Tracking
+
+One GitHub issue per service (see issues labeled `mcp-onboarding`). The parent tracking
+issue links all of them and records phase ordering.


### PR DESCRIPTION
Closes #71 · Refs #52

## Что это

Планирование подключения **всех** сервисов экосистемы DKH к MCP-шлюзу. Документы — план исполнения (код вне scope этого PR; реальные tools генерируются по фактическим gRPC-контрактам и проверяются на CI).

## Содержимое

- `docs/planning/services-onboarding-roadmap.md` — текущее покрытие (10 сервисов), ограничения исполнения, чек-лист онбординга, фазовый план (полный CRUD где уместно; read-only где чувствительно), проработанный пример CartService, legacy на исключение.
- `docs/planning/mcp-onboarding-execution-plan.md` — самодостаточный runbook: **required reading** (`AGENTS.md`→`DKH.AgentRules`, `CONTRIBUTING.md`), **конвенции** (Conventional Commits, branch naming `<type>/<issue>-<desc>`, PR/`Closes #`, squash, quality gates, метки/project board), discovery контрактов, готовые шаблоны generic-CRUD и read-only tools, шаблоны тестов, порядок/параллелизм, индекс по сервисам, Definition of Done.

## Трекинг

Epic #52 + issues #53–#69 (`<type>(<scope>): …`, метка `type:feature`/`type:chore`). Соответствует `CONTRIBUTING.md`.

## ⚠️ Оговорка

Shared-ruleset `agents/DKH.AgentRules` не был доступен в окружении — план помечен «если shared-правила конфликтуют, они главнее»; нужна сверка при доступе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)